### PR TITLE
fix: carry IRevenueSource ERC-165 advertisement in base

### DIFF
--- a/contracts/automated-buybacks/revenue/RevenueSource.sol
+++ b/contracts/automated-buybacks/revenue/RevenueSource.sol
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.23;
 
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {IRevenueSource} from "../../interfaces/IRevenueSource.sol";
 
 /**
@@ -9,6 +10,9 @@ import {IRevenueSource} from "../../interfaces/IRevenueSource.sol";
  * @author swissarmytowel <info@lido.fi>
  * @notice Base contract for revenue data providers. Maintains a monotonic cumulative USD
  *         revenue accumulator and exposes it as the sole read.
+ * @dev    Carries the ERC-165 advertisement for `IRevenueSource` so every concrete source is
+ *         registrable by consumers (e.g. `BuybackAllocator`) without re-declaring it. Children
+ *         that expose extra interfaces override `supportsInterface` and chain through `super`.
  */
 abstract contract RevenueSource is IRevenueSource {
     /*//////////////////////////////////////////////////////////////
@@ -34,6 +38,18 @@ abstract contract RevenueSource is IRevenueSource {
      */
     function getCumulativeRevenueUSD() external view returns (uint256) {
         return _cumulativeRevenueUSD;
+    }
+
+    /**
+     * @notice ERC-165 support. Advertises `IRevenueSource` and `IERC165` for every concrete
+     *         source. Children that add interfaces override and chain via `super`.
+     * @param  interfaceId_ Interface identifier to probe.
+     * @return `true` for `IRevenueSource` and `IERC165`.
+     */
+    function supportsInterface(bytes4 interfaceId_) public view virtual override returns (bool) {
+        return
+            interfaceId_ == type(IRevenueSource).interfaceId ||
+            interfaceId_ == type(IERC165).interfaceId;
     }
 
     /*//////////////////////////////////////////////////////////////

--- a/contracts/automated-buybacks/revenue/StakingRevenueSource.sol
+++ b/contracts/automated-buybacks/revenue/StakingRevenueSource.sol
@@ -2,9 +2,7 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.23;
 
-import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {RevenueSource} from "./RevenueSource.sol";
-import {IRevenueSource} from "../../interfaces/IRevenueSource.sol";
 import {ITokenRatePusherWithArgs} from "../../interfaces/ITokenRatePusherWithArgs.sol";
 import {IOracleRouter} from "../../interfaces/IOracleRouter.sol";
 import {ILidoLocator} from "../../interfaces/ILidoLocator.sol";
@@ -28,7 +26,7 @@ import {IStakingRouter} from "../../interfaces/IStakingRouter.sol";
  *         `ITokenRatePusherWithArgs.interfaceId` is required so `TokenRateNotifier.addObserver`
  *         auto-detects the args-bearing flavor.
  */
-contract StakingRevenueSource is RevenueSource, ITokenRatePusherWithArgs, IERC165 {
+contract StakingRevenueSource is RevenueSource, ITokenRatePusherWithArgs {
     /*//////////////////////////////////////////////////////////////
                               IMMUTABLES
     //////////////////////////////////////////////////////////////*/
@@ -208,14 +206,14 @@ contract StakingRevenueSource is RevenueSource, ITokenRatePusherWithArgs, IERC16
      * @notice ERC165 entry point. Queried by `TokenRateNotifier.addObserver` during
      *         registration to detect the args-bearing observer flavor.
      * @param  interfaceId_ Interface identifier to probe.
-     * @return `true` for `IRevenueSource`, `ITokenRatePusherWithArgs`, and `IERC165`.
-     * @dev    `IRevenueSource` must be advertised so consumers like `BuybackAllocator` accept
-     *         this source via their ERC165 registration check.
+     * @return `true` for `ITokenRatePusherWithArgs`, plus `IRevenueSource` and `IERC165` via the
+     *         base `RevenueSource`.
+     * @dev    `IRevenueSource` / `IERC165` advertisement is inherited from `RevenueSource`, so
+     *         consumers like `BuybackAllocator` accept this source via their ERC165 check.
      */
-    function supportsInterface(bytes4 interfaceId_) external pure returns (bool) {
+    function supportsInterface(bytes4 interfaceId_) public view override returns (bool) {
         return
-            interfaceId_ == type(IRevenueSource).interfaceId ||
             interfaceId_ == type(ITokenRatePusherWithArgs).interfaceId ||
-            interfaceId_ == type(IERC165).interfaceId;
+            super.supportsInterface(interfaceId_);
     }
 }

--- a/contracts/interfaces/IRevenueSource.sol
+++ b/contracts/interfaces/IRevenueSource.sol
@@ -2,13 +2,18 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity 0.8.23;
 
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
 /**
  * @title IRevenueSource
  * @notice Read surface every revenue contributor exposes to the buyback revenue aggregator.
  *         Returns the source's monotonic cumulative revenue in USD; consumers diff successive
  *         reads to derive accrued revenue. Concrete sources extend the abstract `RevenueSource`,
  *         which implements this method.
+ * @dev    Extends `IERC165` so the base `RevenueSource` carries the `supportsInterface`
+ *         advertisement for `IRevenueSource`, and every concrete source inherits it. Consumers
+ *         like `BuybackAllocator` gate registration on `supportsInterface(type(IRevenueSource))`.
  */
-interface IRevenueSource {
+interface IRevenueSource is IERC165 {
     function getCumulativeRevenueUSD() external view returns (uint256);
 }


### PR DESCRIPTION
`RevenueSource` declared the `IRevenueSource` identity but left the ERC-165 `supportsInterface` advertisement to each concrete child. A child omitting the `IRevenueSource` branch is unregisterable by `BuybackAllocator` (the gate reverts `RevenueSourceUnsupported`) — the root cause behind the earlier `StakingRevenueSource` miss.

## Changes
- `IRevenueSource` now extends `IERC165`.
- `RevenueSource` implements `supportsInterface` for `IRevenueSource`/`IERC165` (virtual).
- `StakingRevenueSource` chains via `super`, adds only `ITokenRatePusherWithArgs`.

## Notes
- No interface id or selector changes (`type(IRevenueSource).interfaceId` stays `0x87c92437`; inherited `supportsInterface` is excluded from the id). The `BuybackAllocator` registration gate is unaffected.
- `supportsInterface` return values are unchanged; any future source inherits the advertisement automatically.
- `hardhat compile` passes.