### PR TITLE
feat: add buyback deploy scripts and deployment record

### DIFF
--- a/deployed-mainnet.json
+++ b/deployed-mainnet.json
@@ -1,0 +1,26 @@
+{
+  "oracleRouter": {
+    "implementation": {
+      "contract": "contracts/routers/OracleRouter.sol",
+      "address": "0x79ef3a538200Fe4981D67E7e886bfb36D4Cb5a31",
+      "deployTx": "0x5b10055ad68a135ec447a48ddf73c84c55957ebce35412801eab45358b946299",
+      "constructorArgs": [
+        "0x2e59A20f205bB85a89C53f1936454680651E618e",
+        "0x47Fb2585D2C56Fe188D0E6ec628a38b74fCeeeDf"
+      ]
+    }
+  },
+  "amountConverterEthAnchored": {
+    "implementation": {
+      "contract": "contracts/AmountConverter.sol",
+      "address": "0x70dA04C5D0f325F5AF1426dE6672BF2424B4593d",
+      "deployTx": "0x3d071b5677340c572ff87dd9ae73a853e2fd1df1440c4d45033fe181c3dc7b0d",
+      "constructorArgs": [
+        "0x79ef3a538200Fe4981D67E7e886bfb36D4Cb5a31",
+        ["0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84"],
+        ["0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32"],
+        true
+      ]
+    }
+  }
+}

--- a/scripts/create-stonks-instances.ts
+++ b/scripts/create-stonks-instances.ts
@@ -19,12 +19,40 @@ interface StonksConfig {
   receiver: string
 }
 
-const ADMIN = ''
-const AGENT = ''
-const STONKS_FACTORY = ''
-const AMOUNT_CONVERTER = ''
-const MANAGER_ADDRESS = ''
-const STONKS_CONFIGS: Record<string, StonksConfig> = {}
+const ADMIN = '0x2e59A20f205bB85a89C53f1936454680651E618e' // Aragon Voting
+const AGENT = '0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c' // Aragon Agent
+const STONKS_FACTORY = '' // TODO: deployed StonksFactory
+// ETH-anchored AmountConverter from Stonks V2 deploy
+const AMOUNT_CONVERTER = '0x70dA04C5D0f325F5AF1426dE6672BF2424B4593d'
+const MANAGER_ADDRESS = '' // TODO: deployed BuybackExecutor
+
+const STETH = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84'
+const LDO = '0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32'
+
+const STONKS_CONFIGS: Record<string, StonksConfig> = {
+  // receiver == manager (the executor) => LP mode
+  buybackStonksLp: {
+    tokenFrom: STETH,
+    tokenTo: LDO,
+    orderDurationInSeconds: 1800n, // 30 min
+    marginBasisPoints: 110n, // 1.10%
+    priceToleranceInBasisPoints: 550n, // 5.50%
+    maxImprovementInBasisPoints: 1000n, // 10.00%
+    allowPartialFill: true,
+    receiver: MANAGER_ADDRESS,
+  },
+  // receiver == Aragon Agent => treasury mode, the launch instance
+  buybackStonksTreasury: {
+    tokenFrom: STETH,
+    tokenTo: LDO,
+    orderDurationInSeconds: 1800n, // 30 min
+    marginBasisPoints: 110n, // 1.10%
+    priceToleranceInBasisPoints: 550n, // 5.50%
+    maxImprovementInBasisPoints: 1000n, // 10.00%
+    allowPartialFill: true,
+    receiver: AGENT,
+  },
+}
 
 assert(ethers.isAddress(ADMIN), 'ADMIN is not a valid address')
 assert(ethers.isAddress(AGENT), 'AGENT is not a valid address')

--- a/scripts/create-stonks-instances.ts
+++ b/scripts/create-stonks-instances.ts
@@ -3,7 +3,7 @@ import { ethers, network } from 'hardhat'
 
 import fmt from '../utils/format'
 import { confirmOrAbort } from '../utils/prompt'
-import { getDeployer, verify, waitForDeployment } from '../utils/deployment'
+import { getDeployer, saveDeployment, verify, waitForDeployment } from '../utils/deployment'
 import { StonksFactory__factory } from '../typechain-types'
 import { StonksDeployedEvent } from '../typechain-types/contracts/factories/StonksFactory'
 import { setTimeout } from 'timers/promises'
@@ -110,6 +110,29 @@ async function main() {
         `was deployed successfully: ${fmt.address(stonksAddress)}\n`,
       ].join(' ')
     )
+
+    saveDeployment(pair, {
+      contract: 'contracts/Stonks.sol',
+      address: stonksAddress,
+      deployTx: receipt.hash,
+      constructorArgs: [
+        {
+          admin,
+          agent,
+          manager,
+          tokenFrom,
+          tokenTo,
+          amountConverter,
+          orderSample,
+          orderDurationInSeconds,
+          marginInBasisPoints,
+          priceToleranceInBasisPoints,
+          maxImprovementInBasisPoints,
+          allowPartialFill,
+          receiver,
+        },
+      ],
+    })
 
     console.log('Waiting for 15 seconds to let Etherscan index the new contract...')
 

--- a/scripts/deploy-buyback-allocator.ts
+++ b/scripts/deploy-buyback-allocator.ts
@@ -1,0 +1,120 @@
+import { assert } from 'chai'
+import { ethers, network } from 'hardhat'
+
+import fmt from '../utils/format'
+import { confirmOrAbort } from '../utils/prompt'
+import { getDeployer, saveDeployment, verify, waitForDeployment } from '../utils/deployment'
+import { BuybackAllocator__factory } from '../typechain-types'
+import { BuybackAllocator } from '../typechain-types/contracts/automated-buybacks/BuybackAllocator'
+
+const ADMIN = '0x2e59A20f205bB85a89C53f1936454680651E618e' // Aragon Voting
+const TREASURY = '0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c' // Aragon Agent
+const STETH = '0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84'
+// OracleRouter from Stonks v2 deploy
+const ORACLE_ROUTER = '0x79ef3a538200Fe4981D67E7e886bfb36D4Cb5a31'
+// Receives allocations: the deployed BuybackExecutor
+const EXECUTOR = '' // TODO
+
+// USD limits are 1e18-scaled. Make sure that values below are consistent to deploy plan
+const DAILY_CAP_USD = ethers.parseEther('50000') // $50,000
+const YEARLY_CAP_USD = ethers.parseEther('10000000') // $10,000,000
+const RESERVE_DAILY_RATE_USD = ethers.parseEther('109589') // ~$109,589/day, TODO: confirm exact figure
+const SURPLUS_SHARE_BP = 5000n // 50%
+// Governance lever: 0 disables the stETH price floor
+const MIN_STETH_PRICE_USD = 0n
+// Dust floor per allocation
+const MIN_SPEND_PER_CALL_USD = 0n
+
+const STAKING_REVENUE_SOURCE = '' // TODO
+// Sources registered at deployment. NEST launches with StakingRevenueSource as the only source
+const REVENUE_SOURCES: string[] = [STAKING_REVENUE_SOURCE]
+
+assert(ethers.isAddress(ADMIN), 'ADMIN is not a valid address')
+assert(ethers.isAddress(TREASURY), 'TREASURY is not a valid address')
+assert(ethers.isAddress(STETH), 'STETH is not a valid address')
+assert(ethers.isAddress(ORACLE_ROUTER), 'ORACLE_ROUTER is not a valid address')
+assert(ethers.isAddress(EXECUTOR), 'EXECUTOR is not a valid address')
+assert(DAILY_CAP_USD > 0n, 'DAILY_CAP_USD must be > 0')
+assert(YEARLY_CAP_USD >= DAILY_CAP_USD, 'YEARLY_CAP_USD must be >= DAILY_CAP_USD')
+assert(
+  SURPLUS_SHARE_BP > 0n && SURPLUS_SHARE_BP <= 10000n,
+  'SURPLUS_SHARE_BP must be in (0, 10000]'
+)
+assert(
+  MIN_SPEND_PER_CALL_USD > 0n && MIN_SPEND_PER_CALL_USD <= DAILY_CAP_USD,
+  'MIN_SPEND_PER_CALL_USD must be in (0, DAILY_CAP_USD]'
+)
+assert(REVENUE_SOURCES.length > 0, 'REVENUE_SOURCES is empty')
+assert(REVENUE_SOURCES.length <= 50, 'REVENUE_SOURCES exceeds MAX_REVENUE_SOURCES (50)')
+REVENUE_SOURCES.forEach((source) =>
+  assert(ethers.isAddress(source), `Revenue source ${source} is not a valid address`)
+)
+
+const initParams: BuybackAllocator.ConstructorParamsStruct = {
+  admin: ADMIN,
+  treasury: TREASURY,
+  stEth: STETH,
+  oracleRouter: ORACLE_ROUTER,
+  executor: EXECUTOR,
+  dailyCapUSD: DAILY_CAP_USD,
+  yearlyCapUSD: YEARLY_CAP_USD,
+  reserveDailyRateUSD: RESERVE_DAILY_RATE_USD,
+  minStEthPriceUSD: MIN_STETH_PRICE_USD,
+  minSpendPerCallUSD: MIN_SPEND_PER_CALL_USD,
+  surplusShareBP: SURPLUS_SHARE_BP,
+  revenueSources: REVENUE_SOURCES,
+}
+
+async function main() {
+  // prettier-ignore
+  console.log(
+    `Preparing for ${fmt.name('BuybackAllocator')} deployment on "${fmt.network(network.name)}" network...\n`
+  )
+
+  const deployer = await getDeployer()
+
+  console.log(`Deployment parameters:`)
+  console.log(`  * ${fmt.name('Admin')} address: ${fmt.value(ADMIN)}`)
+  console.log(`  * ${fmt.name('Treasury')} address: ${fmt.value(TREASURY)}`)
+  console.log(`  * ${fmt.name('stETH')} address: ${fmt.value(STETH)}`)
+  console.log(`  * ${fmt.name('OracleRouter')} address: ${fmt.value(ORACLE_ROUTER)}`)
+  console.log(`  * ${fmt.name('Executor')} address: ${fmt.value(EXECUTOR)}`)
+  console.log(`  * daily cap (1e18 USD): ${fmt.value(DAILY_CAP_USD)}`)
+  console.log(`  * yearly cap (1e18 USD): ${fmt.value(YEARLY_CAP_USD)}`)
+  console.log(`  * reserve daily rate (1e18 USD): ${fmt.value(RESERVE_DAILY_RATE_USD)}`)
+  console.log(`  * min stETH price (1e18 USD): ${fmt.value(MIN_STETH_PRICE_USD)}`)
+  console.log(`  * min spend per call (1e18 USD): ${fmt.value(MIN_SPEND_PER_CALL_USD)}`)
+  console.log(`  * surplus share (bps): ${fmt.value(SURPLUS_SHARE_BP)}`)
+  console.log(`  * revenue sources: ${fmt.value('[' + REVENUE_SOURCES.join(', ') + ']')}`)
+  console.log()
+
+  await confirmOrAbort('Proceed?')
+
+  const buybackAllocator = await new BuybackAllocator__factory(deployer).deploy(initParams)
+
+  const receipt = await waitForDeployment(buybackAllocator.deploymentTransaction()!)
+  const buybackAllocatorAddress = await buybackAllocator.getAddress()
+
+  // prettier-ignore
+  console.log(
+    `The ${fmt.name('BuybackAllocator')} contract was deployed successfully: ${fmt.address(buybackAllocatorAddress)}\n`
+  )
+
+  saveDeployment('buybackAllocator', {
+    contract: 'contracts/automated-buybacks/BuybackAllocator.sol',
+    address: buybackAllocatorAddress,
+    deployTx: receipt.hash,
+    constructorArgs: [initParams],
+  })
+
+  if (!['localhost', 'hardhat'].includes(network.name)) {
+    await verify(buybackAllocatorAddress, [initParams], receipt)
+  } else {
+    console.log(`Deployed on the local hardhat network, verification is skipped.`)
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/scripts/deploy-buyback-allocator.ts
+++ b/scripts/deploy-buyback-allocator.ts
@@ -18,12 +18,12 @@ const EXECUTOR = '' // TODO
 // USD limits are 1e18-scaled. Make sure that values below are consistent to deploy plan
 const DAILY_CAP_USD = ethers.parseEther('50000') // $50,000
 const YEARLY_CAP_USD = ethers.parseEther('10000000') // $10,000,000
-const RESERVE_DAILY_RATE_USD = ethers.parseEther('109589') // ~$109,589/day, TODO: confirm exact figure
+const RESERVE_DAILY_RATE_USD = ethers.parseEther('109589') // $109,589/day, $40M/yr baseline
 const SURPLUS_SHARE_BP = 5000n // 50%
 // Governance lever: 0 disables the stETH price floor
 const MIN_STETH_PRICE_USD = 0n
 // Dust floor per allocation
-const MIN_SPEND_PER_CALL_USD = 0n
+const MIN_SPEND_PER_CALL_USD = ethers.parseEther('1000') // $1,000
 
 const STAKING_REVENUE_SOURCE = '' // TODO
 // Sources registered at deployment. NEST launches with StakingRevenueSource as the only source

--- a/scripts/deploy-buyback-executor.ts
+++ b/scripts/deploy-buyback-executor.ts
@@ -17,15 +17,15 @@ const ORACLE_ROUTER = '0x79ef3a538200Fe4981D67E7e886bfb36D4Cb5a31'
 const CURVE_POOL_AND_TOKEN = '0xD7f1dA0a28E39dd0dB70E6Acdc2B49846AD22760'
 
 // Max pool-EMA vs oracle divergence, in (0, 1000]
-const POOL_PRICE_DIVERGENCE_TOLERANCE_BPS = 0n
+const POOL_PRICE_DIVERGENCE_TOLERANCE_BPS = 200n // 2%
 // stETH order bounds. minAllowedOrderAmount in (0, maxAllowedOrderAmount)
-const MIN_ALLOWED_ORDER_AMOUNT = 0n
-const MAX_ALLOWED_ORDER_AMOUNT = 0n
+const MIN_ALLOWED_ORDER_AMOUNT = ethers.parseEther('1') // 1 stETH
+const MAX_ALLOWED_ORDER_AMOUNT = ethers.parseEther('3') // 3 stETH
 // Per-call deposit value bounds, in 1e18-scaled USD. minDepositValueUsd in (0, maxDepositValueUsd)
-const MIN_DEPOSIT_VALUE_USD = 0n
-const MAX_DEPOSIT_VALUE_USD = 0n
+const MIN_DEPOSIT_VALUE_USD = ethers.parseEther('1000') // $1,000
+const MAX_DEPOSIT_VALUE_USD = ethers.parseEther('50000') // $50,000
 // Pool TVL (1e18-scaled USD) at/above which the divergence gate is enforced, in (0, 1_000_000e18]
-const POOL_BOOTSTRAP_MIN_TVL_USD = 0n
+const POOL_BOOTSTRAP_MIN_TVL_USD = ethers.parseEther('250000') // $250,000
 
 assert(ethers.isAddress(ADMIN), 'ADMIN is not a valid address')
 assert(ethers.isAddress(TREASURY), 'TREASURY is not a valid address')

--- a/scripts/deploy-buyback-executor.ts
+++ b/scripts/deploy-buyback-executor.ts
@@ -1,0 +1,122 @@
+import { assert } from 'chai'
+import { ethers, network } from 'hardhat'
+
+import fmt from '../utils/format'
+import { confirmOrAbort } from '../utils/prompt'
+import { getDeployer, saveDeployment, verify, waitForDeployment } from '../utils/deployment'
+import { BuybackExecutor__factory } from '../typechain-types'
+import { BuybackExecutor } from '../typechain-types/contracts/automated-buybacks/BuybackExecutor'
+
+const ADMIN = '0x2e59A20f205bB85a89C53f1936454680651E618e' // Aragon Voting
+const TREASURY = '0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c' // Aragon Agent
+const WSTETH = '0x7f39C581F595B53c5cb19bD0b3f8dA6c935E2Ca0'
+const LDO = '0x5A98FcBEA516Cf06857215779Fd812CA3beF1B32'
+// OracleRouter from Stonks v2 deploy
+const ORACLE_ROUTER = '0x79ef3a538200Fe4981D67E7e886bfb36D4Cb5a31'
+// Pre-existing Curve LDO/wstETH TwoCrypto-NG pool (also the LP token)
+const CURVE_POOL_AND_TOKEN = '0xD7f1dA0a28E39dd0dB70E6Acdc2B49846AD22760'
+
+// Max pool-EMA vs oracle divergence, in (0, 1000]
+const POOL_PRICE_DIVERGENCE_TOLERANCE_BPS = 0n
+// stETH order bounds. minAllowedOrderAmount in (0, maxAllowedOrderAmount)
+const MIN_ALLOWED_ORDER_AMOUNT = 0n
+const MAX_ALLOWED_ORDER_AMOUNT = 0n
+// Per-call deposit value bounds, in 1e18-scaled USD. minDepositValueUsd in (0, maxDepositValueUsd)
+const MIN_DEPOSIT_VALUE_USD = 0n
+const MAX_DEPOSIT_VALUE_USD = 0n
+// Pool TVL (1e18-scaled USD) at/above which the divergence gate is enforced, in (0, 1_000_000e18]
+const POOL_BOOTSTRAP_MIN_TVL_USD = 0n
+
+assert(ethers.isAddress(ADMIN), 'ADMIN is not a valid address')
+assert(ethers.isAddress(TREASURY), 'TREASURY is not a valid address')
+assert(ethers.isAddress(WSTETH), 'WSTETH is not a valid address')
+assert(ethers.isAddress(LDO), 'LDO is not a valid address')
+assert(ethers.isAddress(ORACLE_ROUTER), 'ORACLE_ROUTER is not a valid address')
+assert(ethers.isAddress(CURVE_POOL_AND_TOKEN), 'CURVE_POOL_AND_TOKEN is not a valid address')
+assert(
+  POOL_PRICE_DIVERGENCE_TOLERANCE_BPS > 0n && POOL_PRICE_DIVERGENCE_TOLERANCE_BPS <= 1000n,
+  'POOL_PRICE_DIVERGENCE_TOLERANCE_BPS must be in (0, 1000]'
+)
+assert(
+  MIN_ALLOWED_ORDER_AMOUNT > 0n && MIN_ALLOWED_ORDER_AMOUNT < MAX_ALLOWED_ORDER_AMOUNT,
+  'MIN_ALLOWED_ORDER_AMOUNT must be in (0, MAX_ALLOWED_ORDER_AMOUNT)'
+)
+assert(
+  MIN_DEPOSIT_VALUE_USD > 0n && MIN_DEPOSIT_VALUE_USD < MAX_DEPOSIT_VALUE_USD,
+  'MIN_DEPOSIT_VALUE_USD must be in (0, MAX_DEPOSIT_VALUE_USD)'
+)
+assert(
+  POOL_BOOTSTRAP_MIN_TVL_USD > 0n && POOL_BOOTSTRAP_MIN_TVL_USD <= ethers.parseEther('1000000'),
+  'POOL_BOOTSTRAP_MIN_TVL_USD must be in (0, 1_000_000e18]'
+)
+
+const initParams: BuybackExecutor.InitParamsStruct = {
+  admin: ADMIN,
+  treasury: TREASURY,
+  wstEth: WSTETH,
+  ldo: LDO,
+  oracleRouter: ORACLE_ROUTER,
+  curvePoolAndToken: CURVE_POOL_AND_TOKEN,
+  poolPriceDivergenceToleranceBps: POOL_PRICE_DIVERGENCE_TOLERANCE_BPS,
+  minAllowedOrderAmount: MIN_ALLOWED_ORDER_AMOUNT,
+  maxAllowedOrderAmount: MAX_ALLOWED_ORDER_AMOUNT,
+  minDepositValueUsd: MIN_DEPOSIT_VALUE_USD,
+  maxDepositValueUsd: MAX_DEPOSIT_VALUE_USD,
+  poolBootstrapMinTvlUsd: POOL_BOOTSTRAP_MIN_TVL_USD,
+}
+
+async function main() {
+  // prettier-ignore
+  console.log(
+    `Preparing for ${fmt.name('BuybackExecutor')} deployment on "${fmt.network(network.name)}" network...\n`
+  )
+
+  const deployer = await getDeployer()
+
+  console.log(`Deployment parameters:`)
+  console.log(`  * ${fmt.name('Admin')} address: ${fmt.value(ADMIN)}`)
+  console.log(`  * ${fmt.name('Treasury')} address: ${fmt.value(TREASURY)}`)
+  console.log(`  * ${fmt.name('wstETH')} address: ${fmt.value(WSTETH)}`)
+  console.log(`  * ${fmt.name('LDO')} address: ${fmt.value(LDO)}`)
+  console.log(`  * ${fmt.name('OracleRouter')} address: ${fmt.value(ORACLE_ROUTER)}`)
+  console.log(`  * ${fmt.name('CurvePoolAndToken')} address: ${fmt.value(CURVE_POOL_AND_TOKEN)}`)
+  console.log(
+    `  * pool price divergence tolerance (bps): ${fmt.value(POOL_PRICE_DIVERGENCE_TOLERANCE_BPS)}`
+  )
+  console.log(`  * min allowed order amount (stETH wei): ${fmt.value(MIN_ALLOWED_ORDER_AMOUNT)}`)
+  console.log(`  * max allowed order amount (stETH wei): ${fmt.value(MAX_ALLOWED_ORDER_AMOUNT)}`)
+  console.log(`  * min deposit value (1e18 USD): ${fmt.value(MIN_DEPOSIT_VALUE_USD)}`)
+  console.log(`  * max deposit value (1e18 USD): ${fmt.value(MAX_DEPOSIT_VALUE_USD)}`)
+  console.log(`  * pool bootstrap min TVL (1e18 USD): ${fmt.value(POOL_BOOTSTRAP_MIN_TVL_USD)}`)
+  console.log()
+
+  await confirmOrAbort('Proceed?')
+
+  const buybackExecutor = await new BuybackExecutor__factory(deployer).deploy(initParams)
+
+  const receipt = await waitForDeployment(buybackExecutor.deploymentTransaction()!)
+  const buybackExecutorAddress = await buybackExecutor.getAddress()
+
+  // prettier-ignore
+  console.log(
+    `The ${fmt.name('BuybackExecutor')} contract was deployed successfully: ${fmt.address(buybackExecutorAddress)}\n`
+  )
+
+  saveDeployment('buybackExecutor', {
+    contract: 'contracts/automated-buybacks/BuybackExecutor.sol',
+    address: buybackExecutorAddress,
+    deployTx: receipt.hash,
+    constructorArgs: [initParams],
+  })
+
+  if (!['localhost', 'hardhat'].includes(network.name)) {
+    await verify(buybackExecutorAddress, [initParams], receipt)
+  } else {
+    console.log(`Deployed on the local hardhat network, verification is skipped.`)
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/scripts/deploy-staking-revenue-source.ts
+++ b/scripts/deploy-staking-revenue-source.ts
@@ -1,0 +1,62 @@
+import { assert } from 'chai'
+import { ethers, network } from 'hardhat'
+
+import fmt from '../utils/format'
+import { confirmOrAbort } from '../utils/prompt'
+import { getDeployer, saveDeployment, verify, waitForDeployment } from '../utils/deployment'
+import { StakingRevenueSource__factory } from '../typechain-types'
+
+// OracleRouter from Stonks v2 deploy
+const ORACLE_ROUTER = '0x79ef3a538200Fe4981D67E7e886bfb36D4Cb5a31'
+
+const LIDO_LOCATOR = '0xC1d0b3DE6792Bf6b4b37EccdcC24e45978Cfd2Eb'
+
+assert(ethers.isAddress(ORACLE_ROUTER), 'ORACLE_ROUTER is not a valid address')
+assert(ethers.isAddress(LIDO_LOCATOR), 'LIDO_LOCATOR is not a valid address')
+
+async function main() {
+  // prettier-ignore
+  console.log(
+    `Preparing for ${fmt.name('StakingRevenueSource')} deployment on "${fmt.network(network.name)}" network...\n`
+  )
+
+  const deployer = await getDeployer()
+
+  console.log(`Deployment parameters:`)
+  console.log(`  * ${fmt.name('OracleRouter')} address: ${fmt.value(ORACLE_ROUTER)}`)
+  console.log(`  * ${fmt.name('LidoLocator')} address: ${fmt.value(LIDO_LOCATOR)}`)
+  console.log()
+
+  await confirmOrAbort('Proceed?')
+
+  const stakingRevenueSource = await new StakingRevenueSource__factory(deployer).deploy(
+    ORACLE_ROUTER,
+    LIDO_LOCATOR
+  )
+
+  const receipt = await waitForDeployment(stakingRevenueSource.deploymentTransaction()!)
+  const stakingRevenueSourceAddress = await stakingRevenueSource.getAddress()
+
+  // prettier-ignore
+  console.log(
+    `The ${fmt.name('StakingRevenueSource')} contract was deployed successfully: ${fmt.address(stakingRevenueSourceAddress)}\n`
+  )
+
+  saveDeployment('stakingRevenueSource', {
+    contract: 'contracts/automated-buybacks/revenue/StakingRevenueSource.sol',
+    address: stakingRevenueSourceAddress,
+    deployTx: receipt.hash,
+    constructorArgs: [ORACLE_ROUTER, LIDO_LOCATOR],
+  })
+
+  if (!['localhost', 'hardhat'].includes(network.name)) {
+    await verify(stakingRevenueSourceAddress, [ORACLE_ROUTER, LIDO_LOCATOR], receipt)
+  } else {
+    console.log(`Deployed on the local hardhat network, verification is skipped.`)
+  }
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exitCode = 1
+})

--- a/scripts/deploy-stonks-factory.ts
+++ b/scripts/deploy-stonks-factory.ts
@@ -4,7 +4,7 @@ import { network, ethers } from 'hardhat'
 import fmt from '../utils/format'
 import { confirmOrAbort } from '../utils/prompt'
 import { StonksFactory__factory } from '../typechain-types'
-import { getDeployer, verify, waitForDeployment } from '../utils/deployment'
+import { getDeployer, saveDeployment, verify, waitForDeployment } from '../utils/deployment'
 import { OrderSampleDeployedEvent } from '../typechain-types/contracts/factories/StonksFactory'
 
 const ADMIN = ''
@@ -66,6 +66,28 @@ async function main() {
     `The ${fmt.name('StonksFactory')} contract was deployed successfully: ${fmt.address(stonksFactoryAddress)}\n`
   )
   console.log(`Sample of the ${fmt.name('Order')} contract was deployed at ${fmt.address(order)}\n`)
+
+  // Get domainSeparator from the CoWSwapSettlement contract, which is needed for the Order constructor
+  const settlement = new ethers.Contract(
+    COWSWAP_SETTLEMENT,
+    ['function domainSeparator() view returns (bytes32)'],
+    deployer
+  )
+  const domainSeparator = await settlement.domainSeparator()
+
+  saveDeployment('stonksFactory', {
+    contract: 'contracts/factories/StonksFactory.sol',
+    address: stonksFactoryAddress,
+    deployTx: receipt.hash,
+    constructorArgs: [ADMIN, AGENT, COWSWAP_SETTLEMENT, COWSWAP_VAULT_RELAYER],
+  })
+  saveDeployment('orderSample', {
+    contract: 'contracts/Order.sol',
+    address: order,
+    deployTx: receipt.hash,
+    constructorArgs: [ADMIN, AGENT, COWSWAP_VAULT_RELAYER, domainSeparator],
+  })
+
   if (!['localhost', 'hardhat'].includes(network.name)) {
     await verify(
       stonksFactoryAddress,

--- a/scripts/deploy-stonks-factory.ts
+++ b/scripts/deploy-stonks-factory.ts
@@ -7,10 +7,10 @@ import { StonksFactory__factory } from '../typechain-types'
 import { getDeployer, saveDeployment, verify, waitForDeployment } from '../utils/deployment'
 import { OrderSampleDeployedEvent } from '../typechain-types/contracts/factories/StonksFactory'
 
-const ADMIN = ''
-const AGENT = ''
-const COWSWAP_SETTLEMENT = ''
-const COWSWAP_VAULT_RELAYER = ''
+const ADMIN = '0x2e59A20f205bB85a89C53f1936454680651E618e' // Aragon Voting
+const AGENT = '0x3e40D73EB977Dc6a537aF587D48316feE66E9C8c' // Aragon Agent
+const COWSWAP_SETTLEMENT = '0x9008D19f58AAbD9eD0D60971565AA8510560ab41'
+const COWSWAP_VAULT_RELAYER = '0xC92E8bdf79f0507f65a392b0ab4667716BFE0110'
 assert(ethers.isAddress(ADMIN), 'ADMIN is not a valid address')
 assert(ethers.isAddress(AGENT), 'AGENT is not a valid address')
 assert(ethers.isAddress(COWSWAP_SETTLEMENT), 'COWSWAP_SETTLEMENT is not a valid address')

--- a/utils/deployment.ts
+++ b/utils/deployment.ts
@@ -1,6 +1,37 @@
+import { existsSync, readFileSync, writeFileSync } from 'fs'
+import { join } from 'path'
+
 import fmt from './format'
 import { ContractTransactionResponse, ContractTransactionReceipt, TransactionReceipt } from 'ethers'
 import { ethers, run, network } from 'hardhat'
+
+type DeploymentEntry = {
+  contract: string
+  address: string
+  deployTx?: string
+  constructorArgs?: unknown[]
+}
+
+// Records a deployment in deployed-<network>.json
+export function saveDeployment(name: string, entry: DeploymentEntry) {
+  const file = join(__dirname, '..', `deployed-${network.name}.json`)
+  const current = existsSync(file) ? JSON.parse(readFileSync(file, 'utf8')) : {}
+
+  current[name] = {
+    implementation: {
+      contract: entry.contract,
+      address: entry.address,
+      ...(entry.deployTx ? { deployTx: entry.deployTx } : {}),
+      constructorArgs: entry.constructorArgs ?? [],
+    },
+  }
+  // store bigint as a decimal string since it's not JSON-serializable
+  const replacer = (_: string, value: unknown) =>
+    typeof value === 'bigint' ? value.toString() : value
+
+  writeFileSync(file, JSON.stringify(current, replacer, 2) + '\n')
+  console.log(`Recorded ${fmt.name(name)} in ${fmt.value(`deployed-${network.name}.json`)}`)
+}
 
 export async function getDeployer() {
   // the first address is the deployer account. See the hardhat.config.ts


### PR DESCRIPTION
Add deploy scripts for following buyback contracts: 
- `StakingRevenueSource`;
- `BuybackAllocator`;
- `BuybackExecutor`.

Also, add helper `saveDeployment` to save deploy metadata to json file. Add `deployed-mainnet.json` file with previously deployed Stonks v2 contracts that buyback system will use. 